### PR TITLE
Fix coefficient frame corner artifacts

### DIFF
--- a/bid/ui/styles.py
+++ b/bid/ui/styles.py
@@ -75,7 +75,10 @@ def style_textbox(textbox: ctk.CTkTextbox, size=BASE_FONT_SIZE):
 
 def style_box_frame(frame: ctk.CTkFrame):
     frame.configure(
-        fg_color="transparent",
+        # Fill with the same background color as surrounding widgets so that
+        # labels placed inside the frame don't create visible sharp corners at
+        # the rounded edges.
+        fg_color=BG_COLOR,
         border_color=BORDER_COLOR,
         border_width=2,
         corner_radius=CORNER_RADIUS


### PR DESCRIPTION
## Summary
- fill info box widgets with the background color

## Testing
- `python -m py_compile main.py bid/**/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ddbcd766c832182380155203e8127